### PR TITLE
Add support for HistAI/Spider-breast

### DIFF
--- a/src/thunder/config/dataset/spider_breast.yaml
+++ b/src/thunder/config/dataset/spider_breast.yaml
@@ -1,0 +1,86 @@
+dataset_name: spider_breast
+nb_classes: 18
+base_data_folder: ${oc.env:THUNDER_BASE_DATA_FOLDER}/datasets/
+compatible_tasks:
+  [
+    "alignment_scoring",
+    "embedding_space_visualization",
+    "emir",
+    "image_retrieval",
+    "knn",
+    "knn_ensembling",
+    "linear_probing",
+    "pre_computing_embeddings",
+    "simple_shot",
+    "transformation_invariance",
+    "adversarial_attack",
+  ]
+
+# we split into train and val by WSI 
+# so we do not have a fixed number of train and val samples
+# we only have a fixed number of test samples
+nb_train_samples: None
+nb_val_samples: None
+nb_test_samples: 12034
+image_sizes: [[224, 224]]
+mpp: 0.5
+cancer_type: breast
+classes:
+  [
+    "Adenosis",
+    "Benign phyllodes tumor",
+    "Ductal carcinoma in situ (high-grade)",
+    "Ductal carcinoma in situ (low-grade)",
+    "Fat",
+    "Fibroadenoma",
+    "Fibrocystic changes",
+    "Fibrosis",
+    "Invasive non-special type carcinoma",
+    "Lipogranuloma",
+    "Lobular invasive carcinoma",
+    "Malignant phyllodes tumor",
+    "Necrosis",
+    "Normal ducts",
+    "Normal lobules",
+    "Sclerosing adenosis",
+    "Typical ductal hyperplasia",
+    "Vessels",
+  ]
+class_to_id:
+  "Adenosis": 0
+  "Benign phyllodes tumor": 1
+  "Ductal carcinoma in situ (high-grade)": 2
+  "Ductal carcinoma in situ (low-grade)": 3
+  "Fat": 4
+  "Fibroadenoma": 5
+  "Fibrocystic changes": 6
+  "Fibrosis": 7
+  "Invasive non-special type carcinoma": 8
+  "Lipogranuloma": 9
+  "Lobular invasive carcinoma": 10
+  "Malignant phyllodes tumor": 11
+  "Necrosis": 12
+  "Normal ducts": 13
+  "Normal lobules": 14
+  "Sclerosing adenosis": 15
+  "Typical ductal hyperplasia": 16
+  "Vessels": 17
+id_to_class:
+  0: "Adenosis"
+  1: "Benign phyllodes tumor"
+  2: "Ductal carcinoma in situ (high-grade)"
+  3: "Ductal carcinoma in situ (low-grade)"
+  4: "Fat"
+  5: "Fibroadenoma"
+  6: "Fibrocystic changes"
+  7: "Fibrosis"
+  8: "Invasive non-special type carcinoma"
+  9: "Lipogranuloma"
+  10: "Lobular invasive carcinoma"
+  11: "Malignant phyllodes tumor"
+  12: "Necrosis"
+  13: "Normal ducts"
+  14: "Normal lobules"
+  15: "Sclerosing adenosis"
+  16: "Typical ductal hyperplasia"
+  17: "Vessels"

--- a/src/thunder/datasets/__init__.py
+++ b/src/thunder/datasets/__init__.py
@@ -2,5 +2,6 @@ from .data_splits import generate_splits
 from .dataset import (bach, bracs, break_his, ccrcc, crc, esca, mhist, ocelot,
                       pannuke, patch_camelyon, segpath_epithelial,
                       segpath_lymphocytes, tcga_crc_msi, tcga_tils,
-                      tcga_uniform, wilds)
+                      tcga_uniform, wilds,
+                      spider_breast)
 from .download import download_datasets

--- a/src/thunder/datasets/dataset/__init__.py
+++ b/src/thunder/datasets/dataset/__init__.py
@@ -19,3 +19,4 @@ from .tcga_crc_msi import create_splits_tcga_crc_msi, download_tcga_crc_msi
 from .tcga_tils import create_splits_tcga_tils, download_tcga_tils
 from .tcga_uniform import create_splits_tcga_uniform, download_tcga_uniform
 from .wilds import create_splits_wilds, download_wilds
+from .spider_breast import create_splits_spider_breast, download_spider_breast

--- a/src/thunder/datasets/dataset/spider_breast.py
+++ b/src/thunder/datasets/dataset/spider_breast.py
@@ -1,0 +1,105 @@
+from huggingface_hub import snapshot_download
+
+def download_spider_breast(root_folder: str):
+    import subprocess
+    from huggingface_hub import snapshot_download
+    snapshot_download(repo_id="histai/SPIDER-breast", repo_type="dataset", local_dir=root_folder, local_dir_use_symlinks=False)
+
+    # unpack the tar files 
+    # run cat spider-breast.tar.* | tar -xvf -
+
+    result = subprocess.run(
+        f"cat {root_folder}/spider-breast.tar.* | tar -xvf - -C {root_folder}",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to extract tar files \nError: {result.stderr}")
+
+    # delete the tar files
+    import glob
+    import os
+    tar_files = glob.glob(os.path.join(root_folder, "spider-breast.tar.*"))
+    for tar_file in tar_files:
+        os.remove(tar_file)
+
+    # Convert to imagenet format
+
+    cmd_to_run = (f"python {root_folder}/scripts/convert_to_imagenet.py "
+                  f"--data_dir {root_folder}/SPIDER-breast "
+                  f"--output_dir {root_folder}/center_crop "
+                  f"--context_size 1 --num_workers 16")
+    
+    
+    result = subprocess.run(cmd_to_run, shell=True, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to run command: {cmd_to_run}\nError: {result.stderr}")
+
+def create_splits_spider_breast(base_folder: str, dataset_cfg: dict) -> None:
+    """
+    Generating data splits for the spider breast dataset.
+
+    :param base_folder: path to the main folder after converting to imagenet format.
+    :param dataset_cfg: dataset-specific config.
+    """
+
+    import os
+    import random
+
+    import numpy as np
+
+    from ...utils.constants import UtilsConstants
+    from ...utils.utils import set_seed
+    from ..data_splits import (create_few_shot_training_data,
+                               get_data_from_folder_recursive, init_dict, save_dict)
+
+    # Setting the random seed
+    set_seed(UtilsConstants.DEFAULT_SEED.value)
+
+    # Initializing dict
+
+    spider_breast_data_splits = init_dict()
+
+    # Retrieving all images and labels
+    spider_breast_folder = os.path.join(base_folder, "spider_breast")
+    (
+        train_val_images,
+        train_val_labels,
+    ) = get_data_from_folder_recursive(spider_breast_folder, "center_crop/train", dataset_cfg)
+    # Sampling val samples
+    train_val_images, train_val_labels = (
+        np.array(train_val_images),
+        np.array(train_val_labels),
+    )
+
+    # image names are folders/to/classname/<slide_id>/<image_id>.png
+    # we want to assign images from a single slide to the same split
+
+    slide_names = [item.split("/")[-2] for item in train_val_images]
+    unique_slide_names = list(set(slide_names))
+    val_slide_names = random.sample(unique_slide_names, int(0.2 * len(unique_slide_names)))
+    val_mask = np.array([slide_name in val_slide_names for slide_name in slide_names])
+
+    spider_breast_data_splits["val"]["images"], spider_breast_data_splits["val"]["labels"] = (
+        train_val_images[val_mask].tolist(),
+        train_val_labels[val_mask].tolist(),
+    )
+    spider_breast_data_splits["train"]["images"], spider_breast_data_splits["train"]["labels"] = (
+        train_val_images[~val_mask].tolist(),
+        train_val_labels[~val_mask].tolist(),
+    )
+    # Test samples
+    (
+        spider_breast_data_splits["test"]["images"],
+        spider_breast_data_splits["test"]["labels"],
+    ) = get_data_from_folder_recursive(spider_breast_folder, "center_crop/test", dataset_cfg)
+
+    # dont check dataset characteristics 
+
+    # Few-shot training data
+    spider_breast_data_splits = create_few_shot_training_data(spider_breast_data_splits)
+
+    # Saving dict
+    save_dict(spider_breast_data_splits, os.path.join(base_folder, "data_splits", "spider_breast.json"))

--- a/src/thunder/datasets/download.py
+++ b/src/thunder/datasets/download.py
@@ -102,7 +102,7 @@ def download_dataset(dataset: str):
         logging.info(
             f"Folder {dataset} already exists in {root_folder}, skipping download."
         )
-        return
+        pass
 
     Path(root_folder).mkdir(parents=True, exist_ok=True)
 
@@ -138,5 +138,7 @@ def download_dataset(dataset: str):
         download_mhist(root_folder)
     elif dataset == "bracs":
         download_bracs(root_folder)
+    elif dataset == "spider_breast":
+        download_spider_breast(root_folder)
     else:
         raise ValueError(f"Dataset {dataset} is not supported.")

--- a/src/thunder/utils/constants.py
+++ b/src/thunder/utils/constants.py
@@ -51,6 +51,7 @@ class DatasetConstants(Enum):
         "tcga_tils",
         "tcga_uniform",
         "wilds",
+        "spider_breast",
     ]
 
 


### PR DESCRIPTION
Spider-breast ([Huggingface URL](https://huggingface.co/datasets/histai/SPIDER-breast)) is a patch-level dataset for breast cancer developed by [HistAI](https://huggingface.co/histai). The original dataset supports two image modes:
- Central 224x224 patches
- Full 1120x1120 images including surrounding context (not included in this PR)

Changes:
- Added `spider_breast.py` to `src/thunder/datasets/dataset
    - download_spider_breast function 
        - downloads tar files with HF snapshot downloader
        - extracts tar files using `cat` and `tar` (subprocess call)
        - deletes tar files
        - extracts 224x224 patches and saves them in `data_root/center_crops`, compatible with torchvision ImageFolder
    - create_splits_spider_colorectal
        - We want to use the same train/test splits as the original spider dataset.
        - We allocate 20% of training images to validation. Since each WSI has multiple images, we ensure that all images from a single WSI are in the same split.

- Added `spider_breast.yaml` to `src/thunder/datasets/configs`
    - Config file for spider_breast dataset
    - `nb_train_samples` and `nb_val_samples` are set to None, because this number depends on the seed used for the train/val split.