### PR TITLE
fix: add User-Agent header to download requests

### DIFF
--- a/src/thunder/datasets/utils.py
+++ b/src/thunder/datasets/utils.py
@@ -5,8 +5,10 @@ def download_from_url(url: str, filename: str):
     import requests
     import tqdm
 
+    # User-Agent header is required by some servers (e.g., Zenodo) to allow downloads
+    headers = {"User-Agent": "thunder-bench (https://github.com/MICS-Lab/thunder)"}
     with open(filename, "wb") as f:
-        with requests.get(url, stream=True) as r:
+        with requests.get(url, stream=True, headers=headers) as r:
             r.raise_for_status()
             total = int(r.headers.get("content-length", 0))
 


### PR DESCRIPTION
## Problem

Dataset downloads fail with `403 Forbidden` error when downloading from Zenodo.

```
HTTPError: 403 Client Error: Forbidden for url:
https://zenodo.org/api/records/1214456/files/NCT-CRC-HE-100K.zip/content
```


## Cause

Zenodo (and some other servers) reject HTTP requests that don't include a proper `User-Agent` header. The default Python `requests` library sends `python-requests/x.x.x` as User-Agent, which is being blocked.

## Solution

Add a `User-Agent` header identifying thunder-bench to all download requests in `download_from_url()`.

## Testing

Verified that the CRC dataset download works correctly after applying this fix.